### PR TITLE
Support 'between' comparisons

### DIFF
--- a/src/Ast/ComparisonNode.php
+++ b/src/Ast/ComparisonNode.php
@@ -2,6 +2,15 @@
 
 namespace Krixon\Rules\Ast;
 
+/**
+ * A simple comparison of an identifier against a single, literal value.
+ *
+ * For example:
+ *
+ * foo is "bar"
+ * foo > 5
+ * foo matches "/^[a-z]+$/i"
+ */
 class ComparisonNode implements Node
 {
     private const EQUALS         = 'EQUALS';

--- a/src/Ast/Writer.php
+++ b/src/Ast/Writer.php
@@ -40,13 +40,36 @@ class Writer implements Visitor
 
     public function visitLogical(LogicalNode $node) : void
     {
+        $left  = $node->left();
+        $right = $node->right();
+
+        // Simplify expressions like `foo >= 10 and foo <= 20` to `foo between 10 and 20`.
+        if ($node->isAnd()
+            && $left instanceof ComparisonNode
+            && $right instanceof ComparisonNode
+            && $left->isGreaterThanOrEqualTo()
+            && $right->isLessThanOrEqualTo()) {
+
+            $left->identifier()->accept($this);
+
+            $this->buffer .= ' between ';
+
+            $left->value()->accept($this);
+
+            $this->buffer .= ' and ';
+
+            $right->value()->accept($this);
+
+            return;
+        }
+
         $this->buffer .= '(';
 
-        $node->left()->accept($this);
+        $left->accept($this);
 
         $this->buffer .= $node->isAnd() ? ' and ' : ' or ';
 
-        $node->right()->accept($this);
+        $right->accept($this);
 
         $this->buffer .= ')';
     }

--- a/src/Lexer/Lexer.php
+++ b/src/Lexer/Lexer.php
@@ -15,6 +15,7 @@ class Lexer
         'true'    => Token::BOOLEAN,
         'false'   => Token::BOOLEAN,
         'matches' => Token::MATCHES,
+        'between' => Token::BETWEEN,
     ];
 
     private const ESCAPE_SEQUENCES = [

--- a/src/Lexer/Token.php
+++ b/src/Lexer/Token.php
@@ -4,7 +4,7 @@ namespace Krixon\Rules\Lexer;
 
 class Token
 {
-    public const LEFT_PAREN    = 'LEFT_PAREN';
+    public const LEFT_PAREN     = 'LEFT_PAREN';
     public const RIGHT_PAREN    = 'RIGHT_PAREN';
     public const LEFT_BRACKET   = 'LEFT_BRACKET';
     public const RIGHT_BRACKET  = 'RIGHT_BRACKET';
@@ -22,6 +22,7 @@ class Token
     public const LESS           = 'LESS';
     public const IN             = 'IN';
     public const MATCHES        = 'MATCHES';
+    public const BETWEEN        = 'BETWEEN';
     public const AND            = 'AND';
     public const OR             = 'OR';
     public const EOF            = 'EOF';
@@ -34,6 +35,7 @@ class Token
         self::LESS,
         self::IN,
         self::MATCHES,
+        self::BETWEEN,
     ];
 
     // Technically NOT is a logical operator, but this list only includes binary operators
@@ -51,6 +53,7 @@ class Token
         self::LESS,
         self::IN,
         self::MATCHES,
+        self::BETWEEN,
         self::AND,
         self::OR,
     ];

--- a/src/Parser/DefaultParser.php
+++ b/src/Parser/DefaultParser.php
@@ -154,6 +154,9 @@ class DefaultParser implements Parser
             case TOKEN::MATCHES:
                 $node = $this->parseMatchesComparison($left);
                 break;
+            case TOKEN::BETWEEN:
+                $node = $this->parseBetweenComparison($left);
+                break;
             default:
                 // @codeCoverageIgnoreStart
                 // This has already been validated by matchComparisonOperator(), but is thrown here to
@@ -174,7 +177,7 @@ class DefaultParser implements Parser
     /**
      * @throws SyntaxError
      */
-    private function parseMatchesComparison(Ast\IdentifierNode $identifier) : Ast\Node
+    private function parseMatchesComparison(Ast\IdentifierNode $identifier) : Ast\ComparisonNode
     {
         $this->match(Token::STRING);
 
@@ -183,6 +186,27 @@ class DefaultParser implements Parser
         $this->next();
 
         return Ast\ComparisonNode::matches($identifier, new Ast\StringNode($value));
+    }
+
+
+    /**
+     * @throws SyntaxError
+     */
+    private function parseBetweenComparison(Ast\IdentifierNode $identifier) : Ast\Node
+    {
+        // `foo between 10 and 20` is syntactic sugar for `foo >= 10 and foo <= 20`.
+
+        $a = $this->parseLiteral();
+
+        $this->match(Token::AND);
+        $this->next();
+
+        $b = $this->parseLiteral();
+
+        return Ast\LogicalNode::and(
+            Ast\ComparisonNode::greaterThanOrEqualTo($identifier, $a),
+            Ast\ComparisonNode::lessThanOrEqualTo($identifier, $b)
+        );
     }
 
 

--- a/tests/Functional/Ast/WriterTest.php
+++ b/tests/Functional/Ast/WriterTest.php
@@ -3,6 +3,7 @@
 namespace Krixon\Rules\Tests\Functional\Ast;
 
 use Krixon\Rules\Ast\Writer;
+use Krixon\Rules\Exception\SyntaxError;
 use Krixon\Rules\Parser\DefaultParser;
 use PHPUnit\Framework\TestCase;
 
@@ -14,7 +15,7 @@ class WriterTest extends TestCase
      * @param string $expression
      * @param string $expected
      *
-     * @throws \Krixon\Rules\Exception\SyntaxError
+     * @throws SyntaxError
      */
     public function testProducesExpectedString(string $expression, string $expected = null) : void
     {
@@ -28,7 +29,7 @@ class WriterTest extends TestCase
     }
 
 
-    public function expectedStringProvider() : array
+    public static function expectedStringProvider() : array
     {
         return [
             ['foo is 42'],
@@ -44,6 +45,7 @@ class WriterTest extends TestCase
             ['foo not > 42'],
             ['foo not matches "bar"'],
             ['foo in ["bar", "baz"]'],
+            ['foo between 10 and 20'],
             [
                 'foo is 42 and bar is 666',
                 '(foo is 42 and bar is 666)',

--- a/tests/Functional/CompilingTest.php
+++ b/tests/Functional/CompilingTest.php
@@ -91,6 +91,20 @@ class CompilingTest extends TestCase implements SpecificationGenerator
                 $this->stub('foo', $in, ['a', 2, 3.5])
             ],
             [
+                'foo between 10 and 20',
+                Composite::and(
+                    $this->stub('foo', $gte, 10),
+                    $this->stub('foo', $lte, 20)
+                )
+            ],
+            [
+                'foo between "a" and "z"',
+                Composite::and(
+                    $this->stub('foo', $gte, 'a'),
+                    $this->stub('foo', $lte, 'z')
+                )
+            ],
+            [
                 'foo is "bar" or (deep is 1 and (deeper is 2))',
                 Composite::or(
                     $this->stub('foo', $eq, 'bar'),

--- a/tests/Unit/Parser/DefaultParserTest.php
+++ b/tests/Unit/Parser/DefaultParserTest.php
@@ -45,7 +45,7 @@ class DefaultParserTest extends TestCase
                 [
                     new Token(Token::IDENTIFIER, 'foo', 0),
                 ],
-                'EQUALS | GREATER | GREATER_EQUALS | IN | LESS | LESS_EQUALS | MATCHES',
+                'BETWEEN | EQUALS | GREATER | GREATER_EQUALS | IN | LESS | LESS_EQUALS | MATCHES',
                 'EOF',
             ],
             'Missing literal' => [


### PR DESCRIPTION
Adds syntactic sugar for a value falling within an inclusive range. For example, `foo between 10 and 20` produces AST identical to that produced by `foo >= 10 and foo <= 20`.